### PR TITLE
Add missing bitwise ops: xor, unary not (~), and shifts (#117)

### DIFF
--- a/cmd/skylark/skylark.go
+++ b/cmd/skylark/skylark.go
@@ -32,6 +32,7 @@ func init() {
 	flag.BoolVar(&resolve.AllowSet, "set", resolve.AllowSet, "allow set data type")
 	flag.BoolVar(&resolve.AllowLambda, "lambda", resolve.AllowLambda, "allow lambda expressions")
 	flag.BoolVar(&resolve.AllowNestedDef, "nesteddef", resolve.AllowNestedDef, "allow nested def statements")
+	flag.BoolVar(&resolve.AllowBitwise, "bitwise", resolve.AllowBitwise, "allow bitwise operations (&, |, ^, ~, <<, and >>)")
 }
 
 func main() {

--- a/eval.go
+++ b/eval.go
@@ -437,7 +437,7 @@ func setIndex(fr *Frame, x, y, z Value) error {
 	return nil
 }
 
-// Unary applies a unary operator (+, -, not) to its operand.
+// Unary applies a unary operator (+, -, ~, not) to its operand.
 func Unary(op syntax.Token, x Value) (Value, error) {
 	switch op {
 	case syntax.MINUS:
@@ -451,6 +451,10 @@ func Unary(op syntax.Token, x Value) (Value, error) {
 		switch x.(type) {
 		case Int, Float:
 			return x, nil
+		}
+	case syntax.TILDE:
+		if xint, ok := x.(Int); ok {
+			return xint.Not(), nil
 		}
 	case syntax.NOT:
 		return !x.Truth(), nil
@@ -763,6 +767,48 @@ func Binary(op syntax.Token, x, y Value) (Value, error) {
 					}
 				}
 				return set, nil
+			}
+		}
+
+	case syntax.CIRCUMFLEX:
+		switch x := x.(type) {
+		case Int:
+			if y, ok := y.(Int); ok {
+				return x.Xor(y), nil
+			}
+		case *Set: // symmetric difference
+			if y, ok := y.(*Set); ok {
+				set := new(Set)
+				for _, xelem := range x.elems() {
+					if found, _ := y.Has(xelem); !found {
+						set.Insert(xelem)
+					}
+				}
+				for _, yelem := range y.elems() {
+					if found, _ := x.Has(yelem); !found {
+						set.Insert(yelem)
+					}
+				}
+				return set, nil
+			}
+		}
+
+	case syntax.LTLT, syntax.GTGT:
+		if x, ok := x.(Int); ok {
+			y, err := AsInt32(y)
+			if err != nil {
+				return nil, err
+			}
+			if y < 0 {
+				return nil, fmt.Errorf("negative shift count: %v", y)
+			}
+			if op == syntax.LTLT {
+				if y >= 512 {
+					return nil, fmt.Errorf("shift count too large: %v", y)
+				}
+				return x.Lsh(uint(y)), nil
+			} else {
+				return x.Rsh(uint(y)), nil
 			}
 		}
 

--- a/eval_test.go
+++ b/eval_test.go
@@ -25,6 +25,7 @@ func init() {
 	resolve.AllowNestedDef = true
 	resolve.AllowFloat = true
 	resolve.AllowSet = true
+	resolve.AllowBitwise = true
 }
 
 func TestEvalExpr(t *testing.T) {

--- a/int.go
+++ b/int.go
@@ -134,12 +134,16 @@ func (i Int) Float() Float {
 	return Float(f)
 }
 
-func (x Int) Sign() int     { return x.bigint.Sign() }
-func (x Int) Add(y Int) Int { return Int{new(big.Int).Add(x.bigint, y.bigint)} }
-func (x Int) Sub(y Int) Int { return Int{new(big.Int).Sub(x.bigint, y.bigint)} }
-func (x Int) Mul(y Int) Int { return Int{new(big.Int).Mul(x.bigint, y.bigint)} }
-func (x Int) Or(y Int) Int  { return Int{new(big.Int).Or(x.bigint, y.bigint)} }
-func (x Int) And(y Int) Int { return Int{new(big.Int).And(x.bigint, y.bigint)} }
+func (x Int) Sign() int      { return x.bigint.Sign() }
+func (x Int) Add(y Int) Int  { return Int{new(big.Int).Add(x.bigint, y.bigint)} }
+func (x Int) Sub(y Int) Int  { return Int{new(big.Int).Sub(x.bigint, y.bigint)} }
+func (x Int) Mul(y Int) Int  { return Int{new(big.Int).Mul(x.bigint, y.bigint)} }
+func (x Int) Or(y Int) Int   { return Int{new(big.Int).Or(x.bigint, y.bigint)} }
+func (x Int) And(y Int) Int  { return Int{new(big.Int).And(x.bigint, y.bigint)} }
+func (x Int) Xor(y Int) Int  { return Int{new(big.Int).Xor(x.bigint, y.bigint)} }
+func (x Int) Not() Int       { return Int{new(big.Int).Not(x.bigint)} }
+func (x Int) Lsh(y uint) Int { return Int{new(big.Int).Lsh(x.bigint, y)} }
+func (x Int) Rsh(y uint) Int { return Int{new(big.Int).Rsh(x.bigint, y)} }
 
 // Precondition: y is nonzero.
 func (x Int) Div(y Int) Int {

--- a/internal/compile/compile.go
+++ b/internal/compile/compile.go
@@ -74,12 +74,16 @@ const (
 	PERCENT
 	AMP
 	PIPE
+	CIRCUMFLEX
+	LTLT
+	GTGT
 
 	IN
 
 	// unary operators
 	UPLUS  // x UPLUS x
 	UMINUS // x UMINUS -x
+	TILDE  // x TILDE ~x
 
 	NONE  // - NONE None
 	TRUE  // - TRUE True
@@ -142,6 +146,7 @@ var opcodeNames = [...]string{
 	CALL_KW:     "call_kw ",
 	CALL_VAR:    "call_var",
 	CALL_VAR_KW: "call_var_kw",
+	CIRCUMFLEX:  "circumflex",
 	CJMP:        "cjmp",
 	CONSTANT:    "constant",
 	DUP2:        "dup2",
@@ -152,6 +157,7 @@ var opcodeNames = [...]string{
 	GE:          "ge",
 	GLOBAL:      "global",
 	GT:          "gt",
+	GTGT:        "gtgt",
 	IN:          "in",
 	INDEX:       "index",
 	INPLACE_ADD: "inplace_add",
@@ -163,6 +169,7 @@ var opcodeNames = [...]string{
 	LOAD:        "load",
 	LOCAL:       "local",
 	LT:          "lt",
+	LTLT:        "ltlt",
 	MAKEDICT:    "makedict",
 	MAKEFUNC:    "makefunc",
 	MAKELIST:    "makelist",
@@ -188,6 +195,7 @@ var opcodeNames = [...]string{
 	SLASHSLASH:  "slashslash",
 	SLICE:       "slice",
 	STAR:        "star",
+	TILDE:       "tilde",
 	TRUE:        "true",
 	UMINUS:      "uminus",
 	UNIVERSAL:   "universal",
@@ -207,6 +215,7 @@ var stackEffect = [...]int8{
 	CALL_KW:     variableStackEffect,
 	CALL_VAR:    variableStackEffect,
 	CALL_VAR_KW: variableStackEffect,
+	CIRCUMFLEX:  -1,
 	CJMP:        -1,
 	CONSTANT:    +1,
 	DUP2:        +2,
@@ -217,6 +226,7 @@ var stackEffect = [...]int8{
 	GE:          -1,
 	GLOBAL:      +1,
 	GT:          -1,
+	GTGT:        -1,
 	IN:          -1,
 	INDEX:       -1,
 	INPLACE_ADD: -1,
@@ -228,6 +238,7 @@ var stackEffect = [...]int8{
 	LOAD:        -1,
 	LOCAL:       +1,
 	LT:          -1,
+	LTLT:        -1,
 	MAKEDICT:    +1,
 	MAKEFUNC:    -1,
 	MAKELIST:    variableStackEffect,
@@ -955,7 +966,12 @@ func (fcomp *fcomp) stmt(stmt syntax.Stmt) {
 			syntax.STAR_EQ,
 			syntax.SLASH_EQ,
 			syntax.SLASHSLASH_EQ,
-			syntax.PERCENT_EQ:
+			syntax.PERCENT_EQ,
+			syntax.AMP_EQ,
+			syntax.PIPE_EQ,
+			syntax.CIRCUMFLEX_EQ,
+			syntax.LTLT_EQ,
+			syntax.GTGT_EQ:
 			// augmented assignment: x += y
 
 			var set func()
@@ -1211,6 +1227,8 @@ func (fcomp *fcomp) expr(e syntax.Expr) {
 			fcomp.emit(UPLUS)
 		case syntax.NOT:
 			fcomp.emit(NOT)
+		case syntax.TILDE:
+			fcomp.emit(TILDE)
 		default:
 			log.Fatalf("%s: unexpected unary op: %s", e.OpPos, e.Op)
 		}
@@ -1435,6 +1453,12 @@ func (fcomp *fcomp) binop(pos syntax.Position, op syntax.Token) {
 		fcomp.emit(AMP)
 	case syntax.PIPE:
 		fcomp.emit(PIPE)
+	case syntax.CIRCUMFLEX:
+		fcomp.emit(CIRCUMFLEX)
+	case syntax.LTLT:
+		fcomp.emit(LTLT)
+	case syntax.GTGT:
+		fcomp.emit(GTGT)
 	case syntax.IN:
 		fcomp.emit(IN)
 	case syntax.NOT_IN:

--- a/interp.go
+++ b/interp.go
@@ -131,8 +131,11 @@ loop:
 			compile.SLASH,
 			compile.SLASHSLASH,
 			compile.PERCENT,
-			compile.PIPE,
 			compile.AMP,
+			compile.PIPE,
+			compile.CIRCUMFLEX,
+			compile.LTLT,
+			compile.GTGT,
 			compile.IN:
 			binop := syntax.Token(op-compile.PLUS) + syntax.PLUS
 			if op == compile.IN {
@@ -149,8 +152,13 @@ loop:
 			stack[sp] = z
 			sp++
 
-		case compile.UPLUS, compile.UMINUS:
-			unop := syntax.Token(op-compile.UPLUS) + syntax.PLUS
+		case compile.UPLUS, compile.UMINUS, compile.TILDE:
+			var unop syntax.Token
+			if op == compile.TILDE {
+				unop = syntax.TILDE
+			} else {
+				unop = syntax.Token(op-compile.UPLUS) + syntax.PLUS
+			}
 			x := stack[sp-1]
 			y, err2 := Unary(unop, x)
 			if err2 != nil {

--- a/syntax/grammar.txt
+++ b/syntax/grammar.txt
@@ -32,7 +32,7 @@ ReturnStmt   = 'return' [Expression] .
 BreakStmt    = 'break' .
 ContinueStmt = 'continue' .
 PassStmt     = 'pass' .
-AssignStmt   = Expression ('=' | '+=' | '-=' | '*=' | '/=' | '//=' | '%=') Expression .
+AssignStmt   = Expression ('=' | '+=' | '-=' | '*=' | '/=' | '//=' | '%=' | '&=' | '|=' | '^=' | '<<=' | '>>=') Expression .
 ExprStmt     = Expression .
 
 LoadStmt = 'load' '(' string {',' [identifier '='] string} [','] ')' .
@@ -90,6 +90,7 @@ Binop = 'or'
       | 'and'
       | '==' | '!=' | '<' | '>' | '<=' | '>=' | 'in' | 'not' 'in'
       | '|'
+      | '^'
       | '&'
       | '-' | '+'
       | '*' | '%' | '/' | '//'

--- a/syntax/parse.go
+++ b/syntax/parse.go
@@ -226,7 +226,7 @@ func (p *parser) parseSimpleStmt(stmts []Stmt) []Stmt {
 // small_stmt = RETURN expr?
 //            | PASS | BREAK | CONTINUE
 //            | LOAD ...
-//            | expr ('=' | '+=' | '-=' | '*=' | '/=' | '%=') expr   // assign
+//            | expr ('=' | '+=' | '-=' | '*=' | '/=' | '%=' | '&=' | '|=' | '^=' | '<<=' | '>>=') expr   // assign
 //            | expr
 func (p *parser) parseSmallStmt() Stmt {
 	switch p.tok {
@@ -250,7 +250,7 @@ func (p *parser) parseSmallStmt() Stmt {
 	// Assignment
 	x := p.parseExpr(false)
 	switch p.tok {
-	case EQ, PLUS_EQ, MINUS_EQ, STAR_EQ, SLASH_EQ, SLASHSLASH_EQ, PERCENT_EQ:
+	case EQ, PLUS_EQ, MINUS_EQ, STAR_EQ, SLASH_EQ, SLASHSLASH_EQ, PERCENT_EQ, AMP_EQ, PIPE_EQ, CIRCUMFLEX_EQ, LTLT_EQ, GTGT_EQ:
 		op := p.tok
 		pos := p.nextToken() // consume op
 		rhs := p.parseExpr(false)
@@ -588,7 +588,7 @@ var precedence [maxToken]int8
 
 // preclevels groups operators of equal precedence.
 // Comparisons are nonassociative; other binary operators associate to the left.
-// Unary MINUS and PLUS have higher precedence so are handled in parsePrimary.
+// Unary MINUS, unary PLUS, and TILDE have higher precedence so are handled in parsePrimary.
 // See https://github.com/google/skylark/blob/master/doc/spec.md#binary-operators
 var preclevels = [...][]Token{
 	{OR},  // or
@@ -596,7 +596,9 @@ var preclevels = [...][]Token{
 	{NOT}, // not (unary)
 	{EQL, NEQ, LT, GT, LE, GE, IN, NOT_IN}, // == != < > <= >= in not in
 	{PIPE},                             // |
+	{CIRCUMFLEX},                       // ^
 	{AMP},                              // &
+	{LTLT, GTGT},                       // << >>
 	{MINUS, PLUS},                      // -
 	{STAR, PERCENT, SLASH, SLASHSLASH}, // * % / //
 }
@@ -803,8 +805,8 @@ func (p *parser) parsePrimary() Expr {
 			Rparen: rparen,
 		}
 
-	case MINUS, PLUS:
-		// unary minus/plus:
+	case MINUS, PLUS, TILDE:
+		// unary minus/plus/tilde:
 		tok := p.tok
 		pos := p.nextToken()
 		x := p.parsePrimaryWithSuffix()

--- a/testdata/int.sky
+++ b/testdata/int.sky
@@ -51,6 +51,18 @@ def compound():
   assert.eq(x, 5)
   x %= 3
   assert.eq(x, 2)
+  # use resolve.AllowBitwise to enable the ops:
+  x = 2
+  x &= 1
+  assert.eq(x, 0)
+  x |= 2
+  assert.eq(x, 2)
+  x ^= 3
+  assert.eq(x, 1)
+  x <<= 2
+  assert.eq(x, 4)
+  x >>=2
+  assert.eq(x, 1)
 
 compound()
 
@@ -119,12 +131,24 @@ assert.eq(int("-0o123", 0), -83)
 assert.fails(lambda: int("0123", 0), "invalid literal.*base 0") # valid in Python 2.7
 assert.fails(lambda: int("-0123", 0), "invalid literal.*base 0")
 
-# bitwise union (int|int) and intersection (int&int).
+# bitwise union (int|int), intersection (int&int), XOR (int^int), unary not (~int),
+# left shift (int<<int), and right shift (int>>int).
+# use resolve.AllowBitwise to enable the ops.
 # TODO(adonovan): this is not yet in the Skylark spec,
 # but there is consensus that it should be.
 assert.eq(1|2, 3)
 assert.eq(3|6, 7)
 assert.eq((1|2) & (2|4), 2)
+assert.eq(1 ^ 2, 3)
+assert.eq(2 ^ 2, 0)
+assert.eq(1 | 0 ^ 1, 1) # check | and ^ operators precedence
+assert.eq(~1, -2)
+assert.eq(~-2, 1)
+assert.eq(~0, -1)
+assert.eq(1 << 2, 4)
+assert.eq(2 >> 1, 1)
+assert.fails(lambda: 2 << -1, "negative shift count")
+assert.fails(lambda: 1 << 512, "shift count too large")
 
 # comparisons
 # TODO(adonovan): test: < > == != etc

--- a/testdata/set.sky
+++ b/testdata/set.sky
@@ -47,7 +47,7 @@ y = set([3, 4, 5])
 # set + any is not defined
 assert.fails(lambda: x + y, "unknown.*: set \+ set")
 
-# set | set
+# set | set (use resolve.AllowBitwise to enable it)
 assert.eq(list(set("a".elems()) | set("b".elems())), ["a", "b"])
 assert.eq(list(set("ab".elems()) | set("bc".elems())), ["a", "b", "c"])
 assert.fails(lambda: set() | [], "unknown binary op: set | list")
@@ -66,9 +66,22 @@ assert.eq(list(x.union([5, 1])), [1, 2, 3, 5])
 assert.eq(list(x.union((6, 5, 4))), [1, 2, 3, 6, 5, 4])
 assert.fails(lambda: x.union([1, 2, {}]), "unhashable type: dict")
 
-# intersection, set & set
+# intersection, set & set (use resolve.AllowBitwise to enable it)
 assert.eq(list(set("a".elems()) & set("b".elems())), [])
 assert.eq(list(set("ab".elems()) & set("bc".elems())), ["b"])
+
+# symmetric difference, set ^ set (use resolve.AllowBitwise to enable it)
+assert.eq(set([1, 2, 3]) ^ set([4, 5, 3]), set([1, 2, 4, 5]))
+
+def test_set_augmented_assign():
+  x = set([1, 2, 3])
+  x &= set([2, 3])
+  assert.eq(x, set([2, 3]))
+  x |= set([1])
+  assert.eq(x, set([1, 2, 3]))
+  x ^= set([4, 5, 3])
+  assert.eq(x, set([1, 2, 4, 5]))
+test_set_augmented_assign()
 
 # len
 assert.eq(len(x), 3)


### PR DESCRIPTION
* implement bitwise xor for integers and symmetric difference for sets (^ and ^= operators)
* implement unary ~ operator for integers
* implement left and right bitwise shifts for integers
* enable xor, unary not, and shifts bitwise ops only when -bitwise flag is set
* enable bitwise & and | only when -bitwise flag is set
* add &= and |= operators